### PR TITLE
Use party identifier instead of party tag on last measure wps

### DIFF
--- a/onomap-geoserver/geoserver/src/test/groovy/org/noise_planet/noisecapturegs/TestNoiseCaptureHisto.groovy
+++ b/onomap-geoserver/geoserver/src/test/groovy/org/noise_planet/noisecapturegs/TestNoiseCaptureHisto.groovy
@@ -86,7 +86,7 @@ class TestNoiseCaptureHisto extends GroovyTestCase {
                 new File(TestNoiseCaptureDumpRecords.getResource("track_f720018a-a5db-4859-bd7d-377d29356c6f.zip").file))
         new nc_parse().buildStatistics(connection, null)
         // Fetch data
-        def arrayData = new nc_last_measures().getStats(connection, "")
+        def arrayData = new nc_last_measures().getStats(connection, null)
         assertEquals(3, arrayData.size())
         assertEquals("France", arrayData[0].country)
         assertEquals("Poitou-Charentes", arrayData[0].name_1)
@@ -99,5 +99,19 @@ class TestNoiseCaptureHisto extends GroovyTestCase {
         assertEquals("Loire-Atlantique", arrayData[2].name_3)
         // Check conversion to json
         def jsonData = JsonOutput.toJson(arrayData);
+    }
+
+
+    void testGetLastMeasuresParty() {
+        Sql.LOG.level = java.util.logging.Level.SEVERE
+        // Parse file to database
+        Sql sql = new Sql(connection)
+        sql.execute("INSERT INTO NOISECAPTURE_PARTY(the_geom, title, tag, description, layer_name, filter_area) VALUES ('POLYGON((-1.64616016766905 47.1531855961037,-1.64616016766905 47.1553688595939,-1.64392677851205 47.1553688595939,-1.64392677851205 47.1531855961037,-1.64616016766905 47.1531855961037))','OGRS 2018 event','OGRS_2018'," +
+                "'Open Geospatial consortium 2018','OGRS', true);")
+        assertEquals(1, new nc_parse().processFiles(connection,
+                [new File(TestNoiseCaptureParse.getResource("track_fec26b2a-3345-4e58-9055-1a6567b055ad.zip").file)] as File[], 0, false))
+        // Fetch data
+        def arrayData = new nc_last_measures().getStats(connection, 1)
+        assertEquals(1, arrayData.size())
     }
 }

--- a/onomap-geoserver/geoserver/src/test/resources/org/noise_planet/noisecapturegs/inith2.sql
+++ b/onomap-geoserver/geoserver/src/test/resources/org/noise_planet/noisecapturegs/inith2.sql
@@ -23,9 +23,9 @@ COMMENT ON COLUMN NOISECAPTURE_USER.PROFILE IS 'User acoustic knowledge, one of 
 CREATE TABLE NOISECAPTURE_PARTY (
     PK_PARTY serial NOT NULL,
     THE_GEOM geometry NOT NULL,
-    LAYER_NAME varchar NOT NULL,
+    LAYER_NAME varchar UNIQUE NOT NULL,
     TITLE varchar NOT NULL,
-    TAG varchar UNIQUE NOT NULL,
+    TAG varchar NOT NULL,
     DESCRIPTION varchar NOT NULL,
     START_TIME TIMESTAMPTZ,
     END_TIME TIMESTAMPTZ,
@@ -38,7 +38,7 @@ COMMENT ON COLUMN NOISECAPTURE_PARTY.title IS 'Short NoiseParty title';
 COMMENT ON COLUMN NOISECAPTURE_PARTY.description IS 'Long description of the NoiseParty';
 COMMENT ON COLUMN NOISECAPTURE_PARTY.tag IS 'Tag typed by users';
 COMMENT ON COLUMN NOISECAPTURE_PARTY.the_geom IS 'NoiseParty location';
-COMMENT ON COLUMN NOISECAPTURE_PARTY.layer_name IS 'Geoserver layer name';
+COMMENT ON COLUMN NOISECAPTURE_PARTY.layer_name IS 'Layer name in leaflet url, must be unique';
 
 -- Table: NOISECAPTURE_TRACK
 CREATE TABLE NOISECAPTURE_TRACK (


### PR DESCRIPTION
Two noise party may share the same tag but not the same layer name (leaflet url)

The attribution of the noise party come from the tag, time and area filter.