### PR TITLE
Do not parse measurements that are done after the server time, about …

### DIFF
--- a/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_parse.groovy
+++ b/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_parse.groovy
@@ -112,6 +112,10 @@ def static Integer processFile(Connection connection, File zipFile, boolean stor
             Integer.valueOf(meta.getProperty("pleasantness")) <= 100)) {
         throw new InvalidParameterException("Wrong pleasantness \"" + meta.getProperty("pleasantness") + "\"")
     }
+    // Maximum 15 minutes of time ahead of server time
+    if(Long.valueOf(meta.getProperty("record_utc")) > System.currentTimeMillis() + (15*60*1000)) {
+        throw new InvalidParameterException("Wrong time, superior than server time \"" + epochToRFCTime(Long.valueOf(meta.getProperty("record_utc"))) + "\"")
+    }
 
     def noisecaptureVersion = Integer.valueOf(meta.getProperty("version_number"));
 


### PR DESCRIPTION
Reject measurement that are done after server time.

This is a workaround for now. However Android should take the time from GSM or GPS.