### PR TITLE
Catch json error

### DIFF
--- a/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_dump_records.groovy
+++ b/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_dump_records.groovy
@@ -86,6 +86,7 @@ static def epochToRFCTime(long epochMillisec, String zone) {
 
 static
 def getDump(Connection connection, File outPath, boolean exportTracks, boolean exportMeasures, boolean exportAreas) {
+    Logger logger = LoggerFactory.getLogger("logger_nc_dump_records")
     // gzip then base64 the content (http://www.txtwizard.net/compression)
     final String README_CONTENT = "H4sIAAAAAAAA/9VYbW/bNhD+nl9BBBjQbrYct02bFa4Bt2mzDunL5hb9aNDS2WJDkQpJ2XF//R5SlC2/NMuGrtuCwLAk8u655+4enjwohyMpmeFLlnHHWaqlpNRRxmZGF8zlxN5qYekFL11liI1UZrTI2KgsO0wklIQl56MPo+ej8ctue+3vfNlhHHsKnhHjCy4kn0pilcrIhG0DznJDs2fHuXPl015Pl6Q8ilQXhVY20WbekyIlZcn2dDaVvX5y0jsevsM6do6FU27piLX+LuvVgx4fJsC6YkbMc2eZUPjPxEJkFZcIUjlSuK1nAUcWTQW00WG2wbnlofn7u9gb2OxFA6KNec/VoFcOj44G5fBDxMlKoxEG8OXcMqWZpDlCmmmTAr/KmCWzIOtvIGR8FtwJrVhZmVIDC9NKrsDN1GpZOZIrb4OnaWV4umLYhABKSYBG1rJ5xQ0HTmICJOKBgONgGQsAImEeF69cro0N9CntmCFbggPhs+1xBI6FQV3Ve+N3pMHSdUUqpXUqqgCxdmBKQ65GH59uBRR5SAJFA5exVHJrnx1n3anU6ZUPpADB3anOVqhBc5Xppdq5qs2xz7bbXn08BOHnZFMjysb9TEiyT2tfdc/MSX+2eBiehNh9XkGPYoNUZzR8+X58wR49fPB40AvXQKRNJhR3BIpmZHzkzK6soyJGkT8Y/pg4pOLKJtH+oIeb3udLnuZsRjz0IdLBWUHc+gtwZiPM2rMTBU0kqbnLG9+WQHdm64TBdEHOrLwZz+tUo9iFmuPLjbcSDRehPkFmYNxGjJXEhxTDlqvX43dnj0/6a1+OG7djB5n1DuJK5reBBGTY4mGwP0C/7FmmUqf5rXbR2pUSN8EiFhQli0m9p6piig7264WUIjLAgAO0/8oVanvF+h3W//nJSYednDwN/+zizYf7NU3e5BetAtvrtpuuAmWeFSm+bJVnhNUJTeBvwOFMzNFa7VUW1efKHHaT3ZDLq0lIfhPwWizCXWAQhcd8RSsPEKgWXFZeYFcszbmaE1vmkEbv5YsoW5VZldAOD75y9bUSaDzPXUDEi82GLcv4IoW6ws6lcDn7MSk1OnNdm0FwUl1JWA69mzGn4UTgBt9U2XaeGx5KDovbzNk9RkLgk6oSWcPJh0DFRyUWZCyXELCPdTCvz+FBzASZGEIMso5EEdY3LE3JLQlE+ZhravY9z7lQE5/jqYnlWfsfi7mC4PrHnr/seWdTG+HMBA0mVnvIMmsZichs2wYyJA1xyBIva4EFhwgMVYSahb4vSFpwKEMG8cx5E4GYPdBhyyRsafBecrqujTRkxxLbIZrPbbPlo4/AVg0aPEnYGLkMhYZEZ+QPiHAQ8MzH7aGZ/WqWyCpOD3+SHDbdXsFOun10373oQ1VS3o8We0FygjZu19+dtNF3/WHZu6WHD2rdf789t4+O79CeB9R/7A+TWHFtoQ6S/w1OgVvt/yOnwUFM89LuRn7xfrxdUz7z/iwA+3rq0O3IAPlSbapyrGuuGwFpztpQww7TZN5q+WO4RA3cHIfoDufCo9pia3vT9+HngAq93WgZuxxBkYJ03hvdZ327u92WRFmb0zU94Ul9vNYjq9unQRuxqaUDNlrP/8RSMxV/Nb3rsRnBoJVwHgWdaSTo8dkPoe/Bn8u5i9pb0VaWfeOGPscCwzNR2Z2mg0p6zWv52FdFaAbfF8X32rou4k79eIiu2xnsOnUptlVTefXhm46sxx3czumGz2tt6J8WEehBjUxJysl1Q9nuW9JyuUwQEgb06RyqZhOM3b25EZntRRcW70i/RG/XrYnZvx5F9fBz9dOHZ6dPWLfLPl2Mzx6xTzRlb8iAVm120xgQmW+DyHwTRJKfnjR43lAmQLBtiVroi/09dL3Zc5cdyLWaHDqDw/Y7Hr1ta75yJjhOlFt39VozGrnYfXkIpS1sXVeNgxIDcF3m4bja8zUTxrpJ4xEiO2mr7Ll/f4o9Elb+tdeM5F+Z7LdD2lLo2+P5PoqNN+e7Ee4X/h/43groq3TvRfOd2KbrCVjw41yD6skDluvKYJ5bj+s2jnpxWHVUlNrgrYEW/pebFg2Xo5e/Mb2IP6o9eBTGNs4yNNsbYOSr7ivoGa5+Cg/HXu9bl5VfkrBXmObDgdDPuyUZoTN2z0fQ7eOjs/4dpw/G6sdJktzvRACnJx4m+amUb/142BaD9sE16LlsePQHTUVcJX4UAAA="
 
@@ -157,7 +158,11 @@ def getDump(Connection connection, File outPath, boolean exportTracks, boolean e
                                                                                        noise_level     : track_row.noise_level,
                                                                                        time_length     : track_row.time_length,
                                                                                        tags            : track_row.tags == null ? null : track_row.tags.tokenize(',')]]
-                        lastFileJsonWriter << JsonOutput.toJson(track)
+                        try {                                                               
+                            lastFileJsonWriter << JsonOutput.toJson(track)
+                        } catch(JsonException ex) {
+                            logger.error(String.format("Track %d illegal content", track_row.pk_track), ex);
+                        }
                 }
                 if (lastFileJsonWriter != null) {
                     lastFileJsonWriter << "]\n}\n"

--- a/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_dump_records.groovy
+++ b/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_dump_records.groovy
@@ -31,9 +31,12 @@ import geoserver.GeoServer
 import geoserver.catalog.Store
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
+import groovy.json.JsonException
 import groovy.sql.Sql
 import org.geotools.jdbc.JDBCDataStore
 import org.springframework.security.core.context.SecurityContextHolder
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 import java.sql.Connection
 import java.sql.ResultSet

--- a/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_parse.groovy
+++ b/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_parse.groovy
@@ -30,7 +30,6 @@ package org.noise_planet.noisecapturegs
 
 import geoserver.catalog.Store
 import groovy.json.JsonSlurper
-import groovy.json.JsonException
 import groovy.sql.GroovyRowResult
 import groovy.sql.Sql
 import geoserver.GeoServer

--- a/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_parse.groovy
+++ b/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_parse.groovy
@@ -30,6 +30,7 @@ package org.noise_planet.noisecapturegs
 
 import geoserver.catalog.Store
 import groovy.json.JsonSlurper
+import groovy.json.JsonException
 import groovy.sql.GroovyRowResult
 import groovy.sql.Sql
 import geoserver.GeoServer


### PR DESCRIPTION
fix error in dump
```
2018-04-04 06:51:25,294 ERROR [wps.executor] - Process execution failed
org.geotools.process.ProcessException: javax.script.ScriptException: groovy.json.JsonException: Number Infinity can't be serialized as JSON: infinite are not allowed in JSON.
	at org.geoserver.script.wps.ScriptProcess.execute(ScriptProcess.java:121)
	at org.geoserver.wps.executor.ProcessStartupFilter$ProcessStartupWrapper.execute(ProcessStartupFilter.java:51)
	at org.geoserver.wps.executor.DefaultProcessManager$ProcessCallable.call(DefaultProcessManager.java:201)
	at org.geoserver.wps.executor.DefaultProcessManager$ProcessCallable.call(DefaultProcessManager.java:169)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: javax.script.ScriptException: groovy.json.JsonException: Number Infinity can't be serialized as JSON: infinite are not allowed in JSON.
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.invokeImpl(GroovyScriptEngineImpl.java:405)
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.invokeFunction(GroovyScriptEngineImpl.java:200)
	at org.geoserver.script.ScriptHook.doInvoke(ScriptHook.java:76)
	at org.geoserver.script.ScriptHook.invoke(ScriptHook.java:60)
	at org.geoserver.script.wps.WpsHook.run(WpsHook.java:187)
	at org.geoserver.script.groovy.GroovyWpsHook.run(GroovyWpsHook.java:41)
	at org.geoserver.script.wps.ScriptProcess.execute(ScriptProcess.java:119)
	... 7 more
Caused by: groovy.json.JsonException: Number Infinity can't be serialized as JSON: infinite are not allowed in JSON.
	at groovy.json.JsonOutput.writeNumber(JsonOutput.java:237)
	at groovy.json.JsonOutput.writeObject(JsonOutput.java:277)
	at groovy.json.JsonOutput.writeMap(JsonOutput.java:458)
	at groovy.json.JsonOutput.writeObject(JsonOutput.java:283)
	at groovy.json.JsonOutput.writeMap(JsonOutput.java:458)
	at groovy.json.JsonOutput.toJson(JsonOutput.java:217)
	at groovy.json.JsonOutput$toJson$0.call(Unknown Source)
	at org.noise_planet.noisecapturegs.Script1$_getDump_closure2.doCall(Script1.groovy:160)
	at sun.reflect.GeneratedMethodAccessor568.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:294)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1021)
	at groovy.lang.Closure.call(Closure.java:426)
	at groovy.lang.Closure.call(Closure.java:442)
	at groovy.sql.Sql.eachRow(Sql.java:1196)
	at groovy.sql.Sql.eachRow(Sql.java:1152)
	at groovy.sql.Sql.eachRow(Sql.java:1091)
	at groovy.sql.Sql$eachRow.call(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:48)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:113)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:133)
	at org.noise_planet.noisecapturegs.Script1.getDump(Script1.groovy:122)
	at org.noise_planet.noisecapturegs.Script1$getDump.callStatic(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallStatic(CallSiteArray.java:56)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:194)
	at org.noise_planet.noisecapturegs.Script1.run(Script1.groovy:329)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1212)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1079)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1021)
	at groovy.lang.Closure.call(Closure.java:426)
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.callGlobal(GroovyScriptEngineImpl.java:417)
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.callGlobal(GroovyScriptEngineImpl.java:411)
	at org.codehaus.groovy.jsr223.GroovyScriptEngineImpl.invokeImpl(GroovyScriptEngineImpl.java:400)
	... 13 more
``` 