### PR TITLE
Fix geometry comparaison issue with NoiseCapture party envelope

### DIFF
--- a/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_parse.groovy
+++ b/onomap-geoserver/geoserver/src/main/groovy/org/noise_planet/noisecapturegs/nc_parse.groovy
@@ -263,10 +263,12 @@ def static Integer processFile(Connection connection, File zipFile, boolean stor
 
     // Remove pk_party if the track is out of bounds
     if(idParty != null && startLocation != null) {
-        def queryParty = sql.firstRow("SELECT ST_CONTAINS(THE_GEOM, :geom::geometry) ISCONTAINS, filter_area FROM noisecapture_party WHERE pk_party = :pkparty", [pkparty: idParty, geom : startLocation])
-        if(queryParty.filter_area && !queryParty.iscontains) {
-            sql.execute("UPDATE NOISECAPTURE_TRACK SET PK_PARTY = NULL WHERE PK_TRACK = :pktrack", [pktrack:recordId])
-            idParty = null;
+        sql.eachRow("SELECT ST_CONTAINS(ST_SETSRID(THE_GEOM, 4326), ST_GEOMFROMTEXT(:geom, 4326)) ISCONTAINS, filter_area FROM" +
+                " noisecapture_party WHERE pk_party = :pkparty", [pkparty: idParty, geom : startLocation]) { queryParty ->
+            if(queryParty.filter_area && !queryParty.iscontains) {
+                sql.execute("UPDATE NOISECAPTURE_TRACK SET PK_PARTY = NULL WHERE PK_TRACK = :pktrack", [pktrack:recordId])
+                idParty = null
+            }
         }
     }
 


### PR DESCRIPTION
- Groovy hide sql exception when using FirstRow, so use another method in order to display real sql query exception
- The modified line is now comparing geometry by forcing the same SRID, fix the exception 'Operation on mixed SRID geometries'