### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,10 @@ script:
   - ./gradlew -PdisablePreDex check
   - cd onomap-geoserver/geoserver
   - pwd
-  - travis_retry ./gradlew test --info --stacktrace
+  - ./gradlew test --info --stacktrace
 
 cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
     - $HOME/.android/build-cache
-
-


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
