### PR TITLE
Avoid crash when no app can open a map link

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -163,5 +163,11 @@
             android:exported="true"
             android:label="@string/title_activity_calibration_traffic" />
     </application>
-
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
 </manifest>

--- a/app/src/main/assets/html/about_FR.html
+++ b/app/src/main/assets/html/about_FR.html
@@ -1,156 +1,157 @@
 <html>
-  <head>
-    <meta content="text/html; charset=utf-8" http-equiv="content-type" />
-    <meta name="generator"
-    content="HTML Tidy for HTML5 (experimental) for Windows https://github.com/w3c/tidy-html5/tree/c63cc39" />
-    <title>� propos de NoiseCapture App</title>
-  </head>
-  <body>
-  <basefont size="3" />
-  <link rel="stylesheet" href="style/style.css" />
-  <img src="images/logo_NoiseCapture.png" alt="NoiseCapture App" style="width:100px" />
-  <div id="about_title"></div>
-  <br />
-  <br />� Ifsttar &amp; CNRS - Tous droits r�serv�s
-  <br />Contact - noisecapture[at]noise-planet.org
-  <br />Web - http://noise-planet.org
-  <br />
-  <br />
-  <hr />
-  <br />
-  <span style="color: #0099cc;">Sommaire:</span>
-  <ul>
-    <li>
-      <a href="#about_description">Description</a>
-    </li>
-    <li>
-      <a href="#about_developments">Projet</a>
-    </li>
-    <li>
-      <a href="#about_funding">Partenaires</a>
-    </li>
-    <li>
-      <a href="#about_license">Licence</a>
-    </li>
-    <li>
-      <a href="#about_others_license">Licences tierces</a>
-    </li>
-    <li>
-      <a href="#about_contributing">
-        <span style="text-decoration: underline;">Contribuer</span>
-      </a>
-    </li>
-    <li>
+<head>
+  <meta content="text/html; charset=utf-8" http-equiv="content-type" />
+  <title>À propos de NoiseCapture App</title>
+</head>
+<body>
+<basefont size="3" />
+<link rel="stylesheet" href="style/style.css" />
+<img src="images/logo_NoiseCapture.png" alt="NoiseCapture App" style="width:100px" />
+<div id="about_title"></div>
+<br />
+<br />© Ifsttar &amp; CNRS - Tous droits réservés
+<br />Contact - noisecapture[at]noise-planet.org
+<br />Web - http://noise-planet.org
+<br />
+<br />
+<a target="_blank" href="https://twitter.com/search?q=%40Noise_planet&src=typd"><img title="Follow @Noise_Planet" alt="Follow @Noise_Planet" src="https://img.shields.io/twitter/follow/Noise_Planet.svg?style=social&amp;label=Follow"/></a>
+<a target="_blank" href="https://github.com/Universite-Gustave-Eiffel/NoiseCapture/subscription"> <img title="Watch NoiseCapture" alt="Watch NoiseCapture" src="https://img.shields.io/github/watchers/Universite-Gustave-Eiffel/noisecapture.svg?style=social&amp;label=Watch"/></a>
+<hr />
+<br />
+<span style="color: #0099cc;">Sommaire:</span>
+<ul>
+  <li>
+    <a href="#about_description">Description</a>
+  </li>
+  <li>
+    <a href="#about_developments">Projet</a>
+  </li>
+  <li>
+    <a href="#about_funding">Partenaires</a>
+  </li>
+  <li>
+    <a href="#about_license">Licence</a>
+  </li>
+  <li>
+    <a href="#about_others_license">Licences tierces</a>
+  </li>
+  <li>
+    <a href="#about_contributing">
+      <span style="text-decoration: underline;">Contribuer</span>
+    </a>
+  </li>
+  <li>
       <span style=" text-decoration: underline;">
-        <a href="#about_privacy">Vie priv�e</a>
+        <a href="#about_privacy">Vie privée</a>
       </span>
-    </li>
-  </ul>
-  <h2>
-  <a name="about_description"></a>Description</h2>NoiseCapture App est une application Android d�velopp�e dans le cadre d'un
-  projet de recherche, dont l'objectif est de permettre l'�laboration de cartes de bruit, en mode collaboratif.
-  <br />
-  <br />
-  <h2>
+  </li>
+</ul>
+<h2>
+  <a name="about_description"></a>Description</h2>NoiseCapture App est une application Android développée dans le cadre d'un
+projet de recherche, dont l'objectif est de permettre l'élaboration de cartes de bruit, en mode collaboratif.
+<br />
+<br />
+<h2>
   <a name="about_developments"></a>Projet</h2>NoiseCapture App est le fruit d'une collaboration entre deux laboratoires
-  de recherche Fran�ais, le 
-  <a title="LAE website" href="www.lae.ifsttar.fr">Laboratoire d'Acoustique Environnementale</a> (Ifsttar) et l'�quipe
-  DECIDE du 
-  <a title="Lab-STICC website" href="http://www.lab-sticc.fr/">Lab-STICC</a> (CNRS).
-  <h2>
-  <a name="about_funding"></a>Partenaires</h2>Cette application est issue du projet europ�en 
-  <b>ENERGIC-OD</b> (European Network for Redistributing Geospatial Information to user Communities - Open Data) [ 
-  <a href="http://www.energic-od.eu/">http://www.energic-od.eu/</a>].
-  <br />Le projet ENERGIC-OD a �t� co-financ� par le programme d'appui strat�gique de l'Europe (ICT Policy Support
-  Programme) � travers le Programme-cadre pour la comp�titivit� et l'innovation (CIP), ainsi que par le portail
-  g�ographique ( 
-  <span style="font-weight: bold;">GEOPAL</span>) de la R�gion des Pays de La Loire (
-  <a href="http://www.geopal.org">http://www.geopal.org</a>).
-  <h2>
+de recherche Français, le
+<a title="LAE website" href="www.lae.ifsttar.fr">Laboratoire d'Acoustique Environnementale</a> (Ifsttar) et l'équipe
+DECIDE du
+<a title="Lab-STICC website" href="http://www.lab-sticc.fr/">Lab-STICC</a> (CNRS).
+<h2>
+  <a name="about_funding"></a>Partenaires</h2>Cette application est issue du projet européen
+<b>ENERGIC-OD</b> (European Network for Redistributing Geospatial Information to user Communities - Open Data) [
+<a href="http://www.energic-od.eu/">http://www.energic-od.eu/</a>].
+<br />Le projet ENERGIC-OD a été co-financé par le programme d'appui stratégique de l'Europe (ICT Policy Support
+Programme) à travers le Programme-cadre pour la compétitivité et l'innovation (CIP), ainsi que par le portail
+géographique (
+<span style="font-weight: bold;">GEOPAL</span>) de la Région des Pays de La Loire (
+<a href="http://www.geopal.org">http://www.geopal.org</a>).
+<h2>
   <a name="about_license"></a>Licence</h2>
-  <span style="font-weight: bold;">NoiseCapture App est une application gratuite, d�velopp�e sous la licence &quot;</span>GNU
-  General Public License&quot; version 3.
-  <br />
-  <br />
-  <span style="font-style: italic;">You can redistribute it and/or modify it under the terms of the GNU General Public License as
+<span style="font-weight: bold;">NoiseCapture App est une application gratuite, développée sous la licence &quot;</span>GNU
+General Public License&quot; version 3.
+<br />
+<br />
+<span style="font-style: italic;">You can redistribute it and/or modify it under the terms of the GNU General Public License as
   published by the Free Software Foundation; either version 3 of the License, or (at your option) any later version. NoiseCapture
   App is distributed in the hope that it will be useful,but WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.</span>
-  <h2>
+<h2>
   <a name="about_others_license"></a>Licences tierces</h2>
-  <dl>
-    <dt>
+<dl>
+  <dt>
     <a target="_blank" href="https://github.com/PhilJay/MPAndroidChart">MPAndroidChart</a> (v2.2.5):</dt>
-    <dd>Copyright 2016 Philipp Jahoda. Licensed under the Apache License;</dd>
-  </dl>
-  <dl>
-    <dt>
+  <dd>Copyright 2016 Philipp Jahoda. Licensed under the Apache License;</dd>
+</dl>
+<dl>
+  <dt>
     <a target="_blank" href="http://www.slf4j.org/">slf4j</a> (v1.7.21):</dt>
-    <dd>Copyright (c) 2004-2013, QOS.ch. Source code and binaries are distributed under the MIT license;</dd>
-  </dl>
-  <dl>
-    <dt>
+  <dd>Copyright (c) 2004-2013, QOS.ch. Source code and binaries are distributed under the MIT license;</dd>
+</dl>
+<dl>
+  <dt>
     <a target="_blank"
-    href="DescriptionJTransforms%20is%20the%20first,%20open%20source,%20multithreaded%20FFT%20library%20written%20in%20pure%20Java.%20Currently,%20four%20types%20of%20transforms%20are%20available:%20Discrete%20Fourier%20Transform%20%28DFT%29,%20Discrete%20Cosine%20Transform%20%28DCT%29,%20Discrete%20Sine%20Transform%20%28DST%29%20and%20Discrete%20Hartley%20Transform%20%28DHT%29.%20The%20code%20is%20derived%20from%20General%20Purpose%20FFT%20Package%20written%20by%20Takuya%20Ooura%20and%20from%20Java%20FFTPack%20written%20by%20Baoshe%20Zhang.%20Here%20are%20the%20projects%20that%20use%20JTransforms:%20%20%20%20VisNow%20-%20a%20generic%20visualization%20framework.%20%20%20%20MusicReader%20-%20a%20software%20that%20makes%20reading%20music%20easy%20and%20convenient.%20%20%20%20Spectro-Edit%20-%20a%20software%20for%20showing%20the%20audio%20visually%20in%20a%20time%20vs.%20frequency%20plot.%20%20%20%20yaprnn%20-%20yet%20another%20pattern%20recognizing%20neural%20network.%20%20%20%20ExpertEyes%20-%20an%20open%20source%20eyetracking%20application.%20%20%20%20TarsosDSP%20-%20a%20real-time%20audio%20processing%20framework.%20%20%20%20FFT%20plugin%20for%20Icy%20-%20Fast%20Fourier%20Transform%20for%202D/3D%20images.%20%20%20%20REW%20-%20Room%20EQ%20Wizard.Features%20%20%20%20The%20fastest%20implementation%20of%20DFT,%20DCT,%20DST%20and%20DHT%20in%20pure%20Java%20%28see%20benchmark%29.%20%20%20%201,%202%20and%203-dimensional%20transforms.%20%20%20%20Arbitrary%20size%20of%20the%20data.%20%20%20%20Support%20for%20very%20large%201-dimensional%20arrays%20%28up%20%20to%20263%20elements%29.%20%20%20%20Single%20and%20double%20precision.%20%20%20%201-dimensional%20and%20multi-dimensional%20variants%20of%202D%20and%203D%20transforms.%20%20%20%20Automatic%20multithreading%20-%20threads%20are%20used%20automatically%20if%20#CPUs%20%3E%201.%20%20%20%20Optimized%20FFTs%20for%20real%20input%20data%20%2840%%20faster%20than%20complex%29.Limitations%20%20%20%201-dimensional%20transforms%20for%20not%20power-of-two%20sizes%20are%20sequential%20%28when%20the%20mixed-radix%20is%20used%29.%20%20%20%201-dimensional%20transforms%20for%20power-of-two%20sizes%20can%20use%20only%202%20or%204%20threads.%20%20%20%20The%20number%20of%20threads%20must%20be%20a%20power-of-two%20number.%20%20%20%20Only%20in-place%20transforms%20are%20available.%20%20%20%20Only%20DCT-II%20and%20DCT-III%20are%20available.%20%20%20%20Only%20DST-II%20and%20DST-III%20are%20available.%20%20%20%20Only%20real%20DHT%20is%20available.BenchmarkJTransforms%203.1%20were%20benchmarked%20against%20FFTW%203.3.4.%2016%20threads%20were%20used%20for%20all%20tested%20algorithms.%20Only%20single%20precision,%20in-place%20transforms%20were%20computed.%20The%20timings%20in%20the%20tables%20below%20show%20a%20minimal%20execution%20time%20among%20100%20calls%20of%20each%20transform.%20They%20do%20not%20incorporate%20the%20JVM%20warm-up%20phase%20for%20JTransforms.Benchmark%20code:%20%20%20%20fftwf_benchmark.c%20%20%20%20JTransforms%20benchmarks%20are%20part%20of%20the%20distribution.Testbed:%20%20%20%202%20x%20Intel%20Xeon%20E5-2687W%20%283.1GHz,%2020MB%20Cache%29,%20%20%20%20512%20GB%20RAM,%20%20%20%20OpenSuse%2013.1,%20%20%20%20GCC%204.8.1,%20%20%20%20Oracle%20Java%201.8.0_60,%20%20%20%20Configure%20flags%20for%20FFTW:%20--enable-threads%20--enable-float%20--enable-sse.%20%20%20%20Java%20flags:%20-Xms400G%20-Xmx400G%20-XX:+UseG1GC.Library%20%5C%20Size%20%092%5E18%20%092%5E19%20%092%5E20%20%092%5E21%20%092%5E22%20%092%5E23%20%092%5E24%20%092%5E25JTransforms%20without%20constructor%092.64%095.42%0911.73%0921.39%0969.70%09155.11%09339.05%09678.32JTransforms%20with%20constructor%0910.62%0913.05%0928.56%0953.95%09125.20%09265.31%09556.36%091116.13FFTW_ESTIMATE%20without%20planning%20%092.01%094.22%094.60%096.87%0946.92%0969.87%09192.16%09317.02FFTW_ESTIMATE%20with%20planning%20%098.05%0930.21%0917.98%0917.44%0953.98%0982.23%09201.57%09332.80FFTW_MEASURE%20without%20planning%20%091.27%091.32%095.54%095.80%0927.36%0935.82%09115.15%09131.74FFTW_MEASURE%20with%20planning%20%0912008.53%091596.05%091510.43%094111.33%093925.72%0931026.67%0917122.96%09118312.39Minimal%20execution%20time%20%28in%20milliseconds%29%20for%201D%20complex%20forward%20FFT%20%28powers%20of%20two%29.Library%20%5C%20Size%20%092%5E8%20%092%5E9%20%092%5E10%20%092%5E11%20%092%5E12%20%092%5E13%20%092%5E14%20%092%5E15JTransforms%20without%20constructor%20%281D%20input%29%090.34%091.06%093.62%0921.68%09101.18%09437.29%091838.59%099340.23JTransforms%20with%20constructor%20%281D%20input%29%090.37%091.08%093.65%0921.76%09101.28%09437.47%091838.59%099342.34JTransforms%20without%20constructor%20%282D%20input%29%09%200.32%091.14%09%203.72%0915.75%0971.23%09326.11%091497.02%099213.68JTransforms%20with%20constructor%20%282D%20input%29%09%200.34%091.16%09%203.75%09%2015.84%0971.33%09%20326.27%091497.34%099215.61FFTW_ESTIMATE%20without%20planning%20%091.46%090.93%092.60%0974.89%09394.00%091253.60%097046.70%0930440.67FFTW_ESTIMATE%20with%20planning%20%093.47%092.98%095.24%0977.38%09397.38%091257.47%097051.96%0930451.29FFTW_MEASURE%20without%20planning%20%090.11%090.47%091.52%0911.85%0946.06%09161.59%091063.78%095193.38FFTW_MEASURE%20with%20planning%20%09188.87%09351.94%09828.64%094101.07%0917668.54%0935372.05%0967427.75%09255687.17Minimal%20execution%20time%20%28in%20milliseconds%29%20for%202D%20complex%20forward%20FFT%20%28powers%20of%20two%29.Library%20%5C%20Size%20%092%5E4%20%092%5E5%20%092%5E6%20%092%5E7%20%092%5E8%20%092%5E9%20%092%5E10%20%092%5E11JTransforms%20without%20constructor%20%281D%20input%29%090.33%090.94%090.83%095.30%0990.94%09774.64%0914855.75%09130356.68JTransforms%20with%20constructor%20%281D%20input%29%090.34%090.96%090.87%095.34%0991.01%09774.72%0914855.90%09130356.89JTransforms%20without%20constructor%20%283D%20input%29%090.10%090.85%091.11%097.57%0946.23%09430.94%0911658.06%0996814.16JTransforms%20with%20constructor%20%283D%20input%29%090.11%090.86%091.12%097.61%0946.30%09431.04%0911658.20%0996814.35FFTW_ESTIMATE%20without%20planning%20%090.03%090.06%090.28%092.13%09207.78%091874.07%0925742.89%09segfaultFFTW_ESTIMATE%20with%20planning%20%090.40%090.44%090.68%092.54%09210.14%091876.29%0925745.86%09segfaultFFTW_MEASURE%20without%20planning%20%090.03%090.06%090.31%092.09%0954.22%09265.38%092783.82%09segfaultFFTW_MEASURE%20with%20planning%20%0919.06%0982.60%09256.62%09808.09%096184.67%0927990.87%09180315.01%09segfaultMinimal%20execution%20time%20%28in%20milliseconds%29%20for%203D%20complex%20forward%20FFT%20%28powers%20of%20two%29.LicenseJTransforms%20is%20distributed%20under%20the%20terms%20of%20the%20BSD-2-Clause%20license.DownloadJTransforms%203.1%20is%20available%20on%20maven%20central%20as%3Cdependency%3E%20%20%20%20%3CgroupId%3Ecom.github.wendykierp%3C/groupId%3E%20%20%20%20%3CartifactId%3EJTransforms%3C/artifactId%3E%20%20%20%20%3Cversion%3E3.1%3C/version%3E%20%20%20%20%3Cclassifier%3Ewith-dependencies%3C/classifier%3E%20%3C/dependency%3Eversion%203.1%20%28September%209,%202015%29binary:%20%20%20%20%20JTransforms-3.1-with-dependencies.jardoc:%20%20%20%20%20JTransforms-3.1-javadoc.jarsource:%20%20%20%20%20JTransforms-3.1-sources.jar%20%20%20%20git%20clone%20https://github.com/wendykierp/JTransforms.gitDonationsIf%20you%20have%20found%20this%20library%20useful%20and%20would%20like%20to%20thank%20the%20author,%20you%20can%20make%20a%20donation%20to%20show%20your%20appreciation.Support%20This%20Project">
-    JTransforms</a> (v3.1):</dt>
-    <dd>Copyright (c) 2007 onward, Piotr Wendykier. Source code and binaries are distributed under the BSD 2-Clause license;</dd>
-  </dl>
-  <dl>
-    <dt>
+       href="DescriptionJTransforms%20is%20the%20first,%20open%20source,%20multithreaded%20FFT%20library%20written%20in%20pure%20Java.%20Currently,%20four%20types%20of%20transforms%20are%20available:%20Discrete%20Fourier%20Transform%20%28DFT%29,%20Discrete%20Cosine%20Transform%20%28DCT%29,%20Discrete%20Sine%20Transform%20%28DST%29%20and%20Discrete%20Hartley%20Transform%20%28DHT%29.%20The%20code%20is%20derived%20from%20General%20Purpose%20FFT%20Package%20written%20by%20Takuya%20Ooura%20and%20from%20Java%20FFTPack%20written%20by%20Baoshe%20Zhang.%20Here%20are%20the%20projects%20that%20use%20JTransforms:%20%20%20%20VisNow%20-%20a%20generic%20visualization%20framework.%20%20%20%20MusicReader%20-%20a%20software%20that%20makes%20reading%20music%20easy%20and%20convenient.%20%20%20%20Spectro-Edit%20-%20a%20software%20for%20showing%20the%20audio%20visually%20in%20a%20time%20vs.%20frequency%20plot.%20%20%20%20yaprnn%20-%20yet%20another%20pattern%20recognizing%20neural%20network.%20%20%20%20ExpertEyes%20-%20an%20open%20source%20eyetracking%20application.%20%20%20%20TarsosDSP%20-%20a%20real-time%20audio%20processing%20framework.%20%20%20%20FFT%20plugin%20for%20Icy%20-%20Fast%20Fourier%20Transform%20for%202D/3D%20images.%20%20%20%20REW%20-%20Room%20EQ%20Wizard.Features%20%20%20%20The%20fastest%20implementation%20of%20DFT,%20DCT,%20DST%20and%20DHT%20in%20pure%20Java%20%28see%20benchmark%29.%20%20%20%201,%202%20and%203-dimensional%20transforms.%20%20%20%20Arbitrary%20size%20of%20the%20data.%20%20%20%20Support%20for%20very%20large%201-dimensional%20arrays%20%28up%20%20to%20263%20elements%29.%20%20%20%20Single%20and%20double%20precision.%20%20%20%201-dimensional%20and%20multi-dimensional%20variants%20of%202D%20and%203D%20transforms.%20%20%20%20Automatic%20multithreading%20-%20threads%20are%20used%20automatically%20if%20#CPUs%20%3E%201.%20%20%20%20Optimized%20FFTs%20for%20real%20input%20data%20%2840%%20faster%20than%20complex%29.Limitations%20%20%20%201-dimensional%20transforms%20for%20not%20power-of-two%20sizes%20are%20sequential%20%28when%20the%20mixed-radix%20is%20used%29.%20%20%20%201-dimensional%20transforms%20for%20power-of-two%20sizes%20can%20use%20only%202%20or%204%20threads.%20%20%20%20The%20number%20of%20threads%20must%20be%20a%20power-of-two%20number.%20%20%20%20Only%20in-place%20transforms%20are%20available.%20%20%20%20Only%20DCT-II%20and%20DCT-III%20are%20available.%20%20%20%20Only%20DST-II%20and%20DST-III%20are%20available.%20%20%20%20Only%20real%20DHT%20is%20available.BenchmarkJTransforms%203.1%20were%20benchmarked%20against%20FFTW%203.3.4.%2016%20threads%20were%20used%20for%20all%20tested%20algorithms.%20Only%20single%20precision,%20in-place%20transforms%20were%20computed.%20The%20timings%20in%20the%20tables%20below%20show%20a%20minimal%20execution%20time%20among%20100%20calls%20of%20each%20transform.%20They%20do%20not%20incorporate%20the%20JVM%20warm-up%20phase%20for%20JTransforms.Benchmark%20code:%20%20%20%20fftwf_benchmark.c%20%20%20%20JTransforms%20benchmarks%20are%20part%20of%20the%20distribution.Testbed:%20%20%20%202%20x%20Intel%20Xeon%20E5-2687W%20%283.1GHz,%2020MB%20Cache%29,%20%20%20%20512%20GB%20RAM,%20%20%20%20OpenSuse%2013.1,%20%20%20%20GCC%204.8.1,%20%20%20%20Oracle%20Java%201.8.0_60,%20%20%20%20Configure%20flags%20for%20FFTW:%20--enable-threads%20--enable-float%20--enable-sse.%20%20%20%20Java%20flags:%20-Xms400G%20-Xmx400G%20-XX:+UseG1GC.Library%20%5C%20Size%20%092%5E18%20%092%5E19%20%092%5E20%20%092%5E21%20%092%5E22%20%092%5E23%20%092%5E24%20%092%5E25JTransforms%20without%20constructor%092.64%095.42%0911.73%0921.39%0969.70%09155.11%09339.05%09678.32JTransforms%20with%20constructor%0910.62%0913.05%0928.56%0953.95%09125.20%09265.31%09556.36%091116.13FFTW_ESTIMATE%20without%20planning%20%092.01%094.22%094.60%096.87%0946.92%0969.87%09192.16%09317.02FFTW_ESTIMATE%20with%20planning%20%098.05%0930.21%0917.98%0917.44%0953.98%0982.23%09201.57%09332.80FFTW_MEASURE%20without%20planning%20%091.27%091.32%095.54%095.80%0927.36%0935.82%09115.15%09131.74FFTW_MEASURE%20with%20planning%20%0912008.53%091596.05%091510.43%094111.33%093925.72%0931026.67%0917122.96%09118312.39Minimal%20execution%20time%20%28in%20milliseconds%29%20for%201D%20complex%20forward%20FFT%20%28powers%20of%20two%29.Library%20%5C%20Size%20%092%5E8%20%092%5E9%20%092%5E10%20%092%5E11%20%092%5E12%20%092%5E13%20%092%5E14%20%092%5E15JTransforms%20without%20constructor%20%281D%20input%29%090.34%091.06%093.62%0921.68%09101.18%09437.29%091838.59%099340.23JTransforms%20with%20constructor%20%281D%20input%29%090.37%091.08%093.65%0921.76%09101.28%09437.47%091838.59%099342.34JTransforms%20without%20constructor%20%282D%20input%29%09%200.32%091.14%09%203.72%0915.75%0971.23%09326.11%091497.02%099213.68JTransforms%20with%20constructor%20%282D%20input%29%09%200.34%091.16%09%203.75%09%2015.84%0971.33%09%20326.27%091497.34%099215.61FFTW_ESTIMATE%20without%20planning%20%091.46%090.93%092.60%0974.89%09394.00%091253.60%097046.70%0930440.67FFTW_ESTIMATE%20with%20planning%20%093.47%092.98%095.24%0977.38%09397.38%091257.47%097051.96%0930451.29FFTW_MEASURE%20without%20planning%20%090.11%090.47%091.52%0911.85%0946.06%09161.59%091063.78%095193.38FFTW_MEASURE%20with%20planning%20%09188.87%09351.94%09828.64%094101.07%0917668.54%0935372.05%0967427.75%09255687.17Minimal%20execution%20time%20%28in%20milliseconds%29%20for%202D%20complex%20forward%20FFT%20%28powers%20of%20two%29.Library%20%5C%20Size%20%092%5E4%20%092%5E5%20%092%5E6%20%092%5E7%20%092%5E8%20%092%5E9%20%092%5E10%20%092%5E11JTransforms%20without%20constructor%20%281D%20input%29%090.33%090.94%090.83%095.30%0990.94%09774.64%0914855.75%09130356.68JTransforms%20with%20constructor%20%281D%20input%29%090.34%090.96%090.87%095.34%0991.01%09774.72%0914855.90%09130356.89JTransforms%20without%20constructor%20%283D%20input%29%090.10%090.85%091.11%097.57%0946.23%09430.94%0911658.06%0996814.16JTransforms%20with%20constructor%20%283D%20input%29%090.11%090.86%091.12%097.61%0946.30%09431.04%0911658.20%0996814.35FFTW_ESTIMATE%20without%20planning%20%090.03%090.06%090.28%092.13%09207.78%091874.07%0925742.89%09segfaultFFTW_ESTIMATE%20with%20planning%20%090.40%090.44%090.68%092.54%09210.14%091876.29%0925745.86%09segfaultFFTW_MEASURE%20without%20planning%20%090.03%090.06%090.31%092.09%0954.22%09265.38%092783.82%09segfaultFFTW_MEASURE%20with%20planning%20%0919.06%0982.60%09256.62%09808.09%096184.67%0927990.87%09180315.01%09segfaultMinimal%20execution%20time%20%28in%20milliseconds%29%20for%203D%20complex%20forward%20FFT%20%28powers%20of%20two%29.LicenseJTransforms%20is%20distributed%20under%20the%20terms%20of%20the%20BSD-2-Clause%20license.DownloadJTransforms%203.1%20is%20available%20on%20maven%20central%20as%3Cdependency%3E%20%20%20%20%3CgroupId%3Ecom.github.wendykierp%3C/groupId%3E%20%20%20%20%3CartifactId%3EJTransforms%3C/artifactId%3E%20%20%20%20%3Cversion%3E3.1%3C/version%3E%20%20%20%20%3Cclassifier%3Ewith-dependencies%3C/classifier%3E%20%3C/dependency%3Eversion%203.1%20%28September%209,%202015%29binary:%20%20%20%20%20JTransforms-3.1-with-dependencies.jardoc:%20%20%20%20%20JTransforms-3.1-javadoc.jarsource:%20%20%20%20%20JTransforms-3.1-sources.jar%20%20%20%20git%20clone%20https://github.com/wendykierp/JTransforms.gitDonationsIf%20you%20have%20found%20this%20library%20useful%20and%20would%20like%20to%20thank%20the%20author,%20you%20can%20make%20a%20donation%20to%20show%20your%20appreciation.Support%20This%20Project">
+      JTransforms</a> (v3.1):</dt>
+  <dd>Copyright (c) 2007 onward, Piotr Wendykier. Source code and binaries are distributed under the BSD 2-Clause license;</dd>
+</dl>
+<dl>
+  <dt>
     <a target="_blank" href="http://commons.apache.org/proper/commons-math/">Apache commons-math library</a>:</dt>
-    <dd>Licensed to the Apache Software Foundation (ASF).</dd>
-  </dl>
-  <dl>
-    <dt>
-      <a target="_blank" href="https://github.com/nhaarman/supertooltips">SuperToolTips</a> (v3):</dt>
-    <dd>Copyright 2013 Niek Haarman. Licensed under the Apache License;</dd>
-  </dl>
-  <dl>
-    <dt>
-      <a target="_blank" href="https://github.com/mapbox/supercluster">supercluster</a>:</dt>
-    <dd>Copyright (c) 2016, Mapbox. Licensed under the ISC License;</dd>
-  </dl>
-  <dl>
-    <dt>
-      <a target="_blank" href="https://github.com/Leaflet/Leaflet">Leaflet</a>:</dt>
-    <dd>Copyright (c) 2010-2016, Vladimir Agafonkin. Licensed under the BSD 2-clause "Simplified" License;</dd>
-  </dl>
-  <h2>
+  <dd>Licensed to the Apache Software Foundation (ASF).</dd>
+</dl>
+<dl>
+  <dt>
+    <a target="_blank" href="https://github.com/nhaarman/supertooltips">SuperToolTips</a> (v3):</dt>
+  <dd>Copyright 2013 Niek Haarman. Licensed under the Apache License;</dd>
+</dl>
+<dl>
+  <dt>
+    <a target="_blank" href="https://github.com/mapbox/supercluster">supercluster</a>:</dt>
+  <dd>Copyright (c) 2016, Mapbox. Licensed under the ISC License;</dd>
+</dl>
+<dl>
+  <dt>
+    <a target="_blank" href="https://github.com/Leaflet/Leaflet">Leaflet</a>:</dt>
+  <dd>Copyright (c) 2010-2016, Vladimir Agafonkin. Licensed under the BSD 2-clause "Simplified" License;</dd>
+</dl>
+<h2>
   <a name="about_contributing"></a>Contribuer</h2>
-  <ul>
-    <li>
-    <span style="color: #0099cc;">Contribuer au d�veloppement du code:</span>
-    <br />Votre contribution au d�veloppement de l'application sera fortement appr�ci�e ! Connectez-vous sur GitHub pour
-    cloner le projet : 
+<ul>
+  <li>
+    <span style="color: #0099cc;">Contribuer au développement du code:</span>
+    <br />Votre contribution au développement de l'application sera fortement appréciée ! Connectez-vous sur GitHub pour
+    cloner le projet :
     <a title="https://github.com/Universite-Gustave-Eiffel/NoiseCapture" href="https://github.com/Universite-Gustave-Eiffel/NoiseCapture">
-    <br />https://github.com/Universite-Gustave-Eiffel/NoiseCapture</a></li>
-	<br/>
-    <li>
-      <span style="color: #0099cc;">Signaler des bugs, proposer des �volutions:</span>
-      <br />
-      <a href="https://github.com/Universite-Gustave-Eiffel/NoiseCapture/issues">https://github.com/Universite-Gustave-Eiffel/NoiseCapture/issues</a>
+      <br />https://github.com/Universite-Gustave-Eiffel/NoiseCapture</a></li>
+  <li>
+    <span style="color: #0099cc;">Signaler des bugs, proposer des évolutions:</span>
     <br />
-	</li>
-	<br/>
-	<li>
-      <span style="color: #0099cc;">Proposer une traduction de l'application dans une nouvelle langue:</span>
-      <br />
-      <a href="https://www.transifex.com/LAE/noisecapture">https://www.transifex.com/LAE/noisecapture</a>
-    </li>
-  </ul>
-  <h2>
-  <a name="about_privacy"></a>Vie priv�e</h2>
-  <p>NoiseCapture App respecte votre 
-  <span style="font-weight: bold;">vie priv�e</span>:</p>
-  <ul>
-    <li>vous contr�lez int�gralement la mani�re dont les informations sont envoy�es sur le serveur (menu 
-    <span style="font-weight: bold;">Param�tres</span> de l'application);</li>
-    <li>
-    <span style="text-decoration: underline;">quand le transfert de donn�es est activ�e, seules des donn�es anonymis�es sont
-    transf�r�es</span>;</li>
-    <li>il n'y a aucun enregistrement audio: seules des indicateurs acoustiques sont calcul�s et transf�r�s;</li>
-    <li>
-    <span style="text-decoration: underline;">NoiseCapture App n'a besoin que des permissions strictement n�cessaires � son
-    utilisation (notamment en mati�re de mesure audio et d'acc�s au r�seau)</span>.</li>
-  </ul></body>
+    <a href="https://github.com/Universite-Gustave-Eiffel/NoiseCapture/issues">https://github.com/Universite-Gustave-Eiffel/NoiseCapture/issues</a>
+    <br />
+    <a target="_blank" href="https://github.com/Universite-Gustave-Eiffel/NoiseCapture#fork-destination-box"><img title="Fork NoiseCapture" alt="Fork NoiseCapture" src="https://img.shields.io/github/forks/Universite-Gustave-Eiffel/noisecapture.svg?style=social&amp;label=Fork" /></a>
+    <a target="_blank" href="https://github.com/Universite-Gustave-Eiffel/NoiseCapture/subscription"><img title="Watch NoiseCapture" alt="Watch NoiseCapture" src="https://img.shields.io/github/watchers/Universite-Gustave-Eiffel/noisecapture.svg?style=social&amp;label=Watch" /></a>
+    <a target="_blank" href="https://github.com/Universite-Gustave-Eiffel/NoiseCapture/issues"><img title="NoiseCapture Issues" alt="NoiseCapture Issues" src="https://img.shields.io/github/issues/Universite-Gustave-Eiffel/noisecapture.svg?maxAge=2592000" /></a>
+  </li>
+  <li>
+    <span style="color: #0099cc;">Proposer une traduction de l'application dans une nouvelle langue:</span>
+    <br />
+    <a href="https://www.transifex.com/LAE/noisecapture">https://www.transifex.com/LAE/noisecapture</a>
+  </li>
+</ul>
+<h2>
+  <a name="about_privacy"></a>Vie privée</h2>
+<p>NoiseCapture App respecte votre
+  <span style="font-weight: bold;">vie privée</span>:</p>
+<ul>
+  <li>vous contrôlez intégralement la manière dont les informations sont envoyées sur le serveur (menu
+    <span style="font-weight: bold;">Paramètres</span> de l'application);</li>
+  <li>
+    <span style="text-decoration: underline;">quand le transfert de données est activée, seules des données anonymisées sont
+    transférées</span>;</li>
+  <li>il n'y a aucun enregistrement audio: seules des indicateurs acoustiques sont calculés et transférés;</li>
+  <li>
+    <span style="text-decoration: underline;">NoiseCapture App n'a besoin que des permissions strictement nécessaires à son
+    utilisation (notamment en matière de mesure audio et d'accès au réseau)</span>.</li>
+</ul></body>
 </html>

--- a/app/src/main/assets/html/map_measurement.html
+++ b/app/src/main/assets/html/map_measurement.html
@@ -94,7 +94,7 @@
     }
 
 
-	var onomap = L.tileLayer('https://onomap-gs.noise-planet.org/geoserver/gwc/service/tms/1.0.0/noisecapture:noisecapture_area_laeq@EPSG:900913@png/{z}/{x}/{y}.png', {
+	var onomap = L.tileLayer('https://data.noise-planet.org/geoserver/gwc/service/tms/1.0.0/noisecapture:noisecapture_area@EPSG:900913@png/{z}/{x}/{y}.png', {
 	tms: true,
 	zIndex: 2,
 	opacity: 0.5,

--- a/app/src/main/assets/html/map_result.js
+++ b/app/src/main/assets/html/map_result.js
@@ -70,14 +70,14 @@ function addMeasurementPoints(GeoJSONFeatures) {
 
 userMeasurementPoints.addTo(map);
 
-var onomap_tiles = L.tileLayer('https://onomap-gs.noise-planet.org/geoserver/gwc/service/tms/1.0.0/noisecapture:noisecapture_area_laeq@EPSG:900913@png/{z}/{x}/{y}.png', {
+var onomap_tiles = L.tileLayer('https://data.noise-planet.org/geoserver/gwc/service/tms/1.0.0/noisecapture:noisecapture_area@EPSG:900913@png/{z}/{x}/{y}.png', {
 tms: true,
 zIndex: 2,
 maxZoom: 19,
 minZoom: 14
 });
 
-var onomap_cluster = L.geoJSON.OnoMap('https://onomap-gs.noise-planet.org/geoserver/ows');
+var onomap_cluster = L.geoJSON.OnoMap('https://data.noise-planet.org/geoserver/ows');
 
 var onomap = L.featureGroup([onomap_tiles, onomap_cluster])
 
@@ -97,7 +97,7 @@ var legend = L.control({position: 'bottomleft'});
 legend.onAdd = function (map) {
 
     var div = L.DomUtil.create('div', 'info legend');
-    div.innerHTML = "<img src='https://onomap-gs.noise-planet.org/geoserver/gwc/service/wms?REQUEST=GetLegendGraphic&VERSION=1.3.0&FORMAT=image/png&LAYER=noisecapture:noisecapture_area&legend_options=fontName:Cerdana;fontAntiAliasing:true;fontColor:0x000033;fontSize:12;dpi:80&TRANSPARENT=true'/>";
+    div.innerHTML = "<img src='https://data.noise-planet.org/geoserver/gwc/service/wms?REQUEST=GetLegendGraphic&VERSION=1.3.0&FORMAT=image/png&LAYER=noisecapture:noisecapture_area&legend_options=fontName:Cerdana;fontAntiAliasing:true;fontColor:0x000033;fontSize:12;dpi:80&TRANSPARENT=true'/>";
     return div;
 };
 

--- a/app/src/main/java/org/noise_planet/noisecapture/MapFragment.java
+++ b/app/src/main/java/org/noise_planet/noisecapture/MapFragment.java
@@ -27,6 +27,7 @@
 
 package org.noise_planet.noisecapture;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.location.Location;
 import android.net.Uri;
@@ -39,6 +40,7 @@ import android.view.ViewGroup;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
+import android.widget.Toast;
 
 
 import java.io.File;
@@ -96,7 +98,11 @@ public class MapFragment extends Fragment {
                 @Override
                 public boolean shouldOverrideUrlLoading(WebView view, String url) {
                     Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                    startActivity(browserIntent);
+                    try {
+                        startActivity(browserIntent);
+                    } catch (ActivityNotFoundException e) {
+                        Toast.makeText(getContext(), "No app found to open this link", Toast.LENGTH_SHORT).show();
+                    }
                     return true;
                 }
             });

--- a/app/src/main/java/org/noise_planet/noisecapture/MapFragment.java
+++ b/app/src/main/java/org/noise_planet/noisecapture/MapFragment.java
@@ -43,7 +43,6 @@ import android.webkit.WebViewClient;
 import android.widget.Toast;
 
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -97,14 +96,22 @@ public class MapFragment extends Fragment {
 
                 @Override
                 public boolean shouldOverrideUrlLoading(WebView view, String url) {
+                    if (url == null) return false;
                     Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                    try {
-                        startActivity(browserIntent);
-                    } catch (ActivityNotFoundException e) {
-                        Toast.makeText(getContext(), "No app found to open this link", Toast.LENGTH_SHORT).show();
+                    if (browserIntent.resolveActivity(getContext().getPackageManager()) != null) {
+                        try {
+                            startActivity(browserIntent);
+                            return true;
+                        } catch (ActivityNotFoundException e) {
+                            Toast.makeText(getContext(), R.string.webview_error_open_link, Toast.LENGTH_SHORT).show();
+                        }
+                    } else {
+                        Toast.makeText(getContext(), R.string.webview_error_unsupported_link, Toast.LENGTH_SHORT).show();
                     }
-                    return true;
+                    return false;
                 }
+
+
             });
             if(mapFragmentAvailableListener != null) {
                 mapFragmentAvailableListener.onMapFragmentAvailable(this);

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -339,4 +339,6 @@
     <string name="result_laeq">LAeq</string>
     <string name="result_linechart_description">التطور الزمني لمستويات الضوضاء بالديسيبل (أ)</string>
     <string name="result_tab_linechart">الوقت</string>
+    <string name="webview_error_unsupported_link">لم يتم العثور على تطبيق للتعامل مع هذا النوع من الروابط.</string>
+    <string name="webview_error_open_link">مطلوب متصفح ويب لفتح هذا الرابط.</string>
 </resources>

--- a/app/src/main/res/values-co/strings.xml
+++ b/app/src/main/res/values-co/strings.xml
@@ -312,4 +312,6 @@ track.geojson: scadìglie misurate ogni segonda aduprendu u furmatu geojson (htt
     <string name="auto_calibration_guest">Calibrà u mo funinu à pàrtesi da un antru funinu digià calibratu cù NoiseCapture</string>
     <string name="calibration_manual_ref">U prucedimentu di calibrera necessiteghja l\'adopru d\'un apparechju di riferenza digià calibratu, cum\'è un sunòmetru. Si veca nant\'à a<a href="org.noise_planet.noisecapture:///android_asset/html/help_FR.html#smartphone_calibration">pàgina d\'aiutu </a>di l\'appiecazione da ottene di più infurmazioni.</string>
     <string name="calibration_manual_calibrator">U prucedimentu di calibrera necessiteghja l\'adopru d\'un calibratore acùsticu. Si veca nant\'à a <a href="org.noise_planet.noisecapture:///android_asset/html/help_FR.html#smartphone_calibration">pàgina d\'aiutu </a> di l\'appiecazione da ottene di più infurmazioni.</string>
-    </resources>
+    <string name="webview_error_unsupported_link">Nisun\'appiecazione trovata per trattà stu tipu di ligame.</string>
+    <string name="webview_error_open_link">Un navigatore web hè necessariu per apre stu ligame.</string>
+</resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -335,4 +335,6 @@ track.geojson 1s vzorky měření. Použití formátu geojson (http://geojson.io
     <string name="result_laeq">LAeq</string>
     <string name="result_linechart_description">Časový vývoj hladin hluku v dB(A)</string>
     <string name="result_tab_linechart">Čas</string>
+    <string name="webview_error_unsupported_link">Nebyla nalezena žádná aplikace pro tento typ odkazu.</string>
+    <string name="webview_error_open_link">Pro otevření tohoto odkazu je vyžadován webový prohlížeč.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -339,4 +339,6 @@ track.geojson 1s Beispielmessungen. Nutzung des geojson-Formats (http://geojson.
     <string name="result_laeq">LAeq</string>
     <string name="result_linechart_description">Zeitliche Entwicklung der Lärmpegel in dB(A)</string>
     <string name="result_tab_linechart">Zeit</string>
+    <string name="webview_error_unsupported_link">Keine App gefunden, um diesen Link-Typ zu öffnen.</string>
+    <string name="webview_error_open_link">Ein Webbrowser ist erforderlich, um diesen Link zu öffnen.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -336,4 +336,6 @@ Utilice su propio smartphone para calibrar otros smartphones.</string>
     <string name="result_laeq">LAeq</string>
     <string name="result_linechart_description">Evolución temporal de los niveles de ruido en dB(A)</string>
     <string name="result_tab_linechart">Tiempo</string>
+    <string name="webview_error_unsupported_link">No se encontró ninguna aplicación para manejar este tipo de enlace.</string>
+    <string name="webview_error_open_link">Se requiere un navegador web para abrir este enlace.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -334,4 +334,6 @@ track.geojson échantillons mesurés chaque seconde au format geojson (http://ge
     <string name="result_laeq">LAeq</string>
     <string name="result_linechart_description">Évolution temporelle des niveaux de bruit en dB(A)</string>
     <string name="result_tab_linechart">Temps</string>
+    <string name="webview_error_unsupported_link">Aucune application trouvée pour gérer ce type de lien.</string>
+    <string name="webview_error_open_link">Un navigateur web est nécessaire pour ouvrir ce lien.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -335,4 +335,6 @@ track.geojson Campioni da 1 secondo delle misurazioni. In formato geojson (http:
     <string name="result_laeq">LAeq</string>
     <string name="result_linechart_description">Evoluzione temporale dei livelli di rumore in dB(A)</string>
     <string name="result_tab_linechart">Tempo</string>
+    <string name="webview_error_unsupported_link">Nessuna applicazione trovata per gestire questo tipo di link.</string>
+    <string name="webview_error_open_link">È necessario un browser web per aprire questo link.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -339,4 +339,6 @@ track.geojson 1s samples of measures. Using the geojson format (http://geojson.i
     <string name="result_laeq">LAeq</string>
     <string name="result_linechart_description">Temporal evolution of noise levels in dB(A)</string>
     <string name="result_tab_linechart">Time</string>
+    <string name="webview_error_unsupported_link">No app found to handle this type of link.</string>
+    <string name="webview_error_open_link">A web browser is required to open this link.</string>
 </resources>


### PR DESCRIPTION
`MapFragment` opens links tapped in the map WebView with `startActivity(ACTION_VIEW)`. If the device has no app that can handle the link this throws `ActivityNotFoundException` and crashes the app.

This wraps the launch in a try/catch and shows a short toast when nothing can open the link. Behaviour is unchanged when a handler exists.

Closes #435
